### PR TITLE
Added support for multiple manifest files

### DIFF
--- a/src/Illuminate/Foundation/helpers.php
+++ b/src/Illuminate/Foundation/helpers.php
@@ -567,7 +567,7 @@ if (! function_exists('mix')) {
      */
     function mix($path, $manifestDirectory = '')
     {
-        static $manifest;
+        static $manifests = [];
 
         if (! starts_with($path, '/')) {
             $path = "/{$path}";
@@ -577,16 +577,21 @@ if (! function_exists('mix')) {
             $manifestDirectory = "/{$manifestDirectory}";
         }
 
+		$manifestKey = $manifestDirectory ? $manifestDirectory : '/';
+
         if (file_exists(public_path($manifestDirectory.'/hot'))) {
             return new HtmlString("//localhost:8080{$path}");
         }
 
-        if (! $manifest) {
+		if (in_array($manifestKey, $manifests)){
+			$manifest = $manifests[$manifestKey];
+		} else {
             if (! file_exists($manifestPath = public_path($manifestDirectory.'/mix-manifest.json'))) {
                 throw new Exception('The Mix manifest does not exist.');
             }
 
             $manifest = json_decode(file_get_contents($manifestPath), true);
+			$manifests[$manifestKey] = $manifest;
         }
 
         if (! array_key_exists($path, $manifest)) {


### PR DESCRIPTION
Currently if you try to use two different manifest files, only the first one is cached and the second one breaks.

	<script src="{{ mix('app.js') }}"></script>
	<script src="{{ mix('comments.js', 'vendor/comments') }}"></script> <-- Breaks

This code caches all of the manifest files, to allow all of them to be used together.